### PR TITLE
Fix code that generates E_NOTICE's

### DIFF
--- a/lib/core/entities/DrPublishApiClientTag.php
+++ b/lib/core/entities/DrPublishApiClientTag.php
@@ -12,8 +12,14 @@ class DrPublishApiClientTag extends DrPublishApiClientArticleEntity
     public function __construct($data)
     {
         parent::__construct($data);
-        $this->tagTypeId = $data->tagType->id;
-        $this->tagTypeName = $data->tagType->name;
+
+        if (!empty($data->tagType->id)) {
+            $this->tagTypeId = $data->tagType->id;
+        }
+
+        if (!empty($data->tagType->name)) {
+            $this->tagTypeName = $data->tagType->name;
+        }
     }
 
     public function getTagTypeName()


### PR DESCRIPTION
The client issues notices when `$data->tagType` is empty, which occurs from time to time. This PR fixes this by setting the values only when `$data->tagType` contains data.
