### PR TITLE
Clone the XML element in order to support thumbnail generation

### DIFF
--- a/lib/core/content/DrPublishApiClientArticleImageElement.php
+++ b/lib/core/content/DrPublishApiClientArticleImageElement.php
@@ -79,7 +79,7 @@ class DrPublishApiClientArticleImageElement extends DrPublishDomElement
     public function getImage()
     {
         if ($this->dpClientImage === null) {
-            $imageElement = $this->domElement->getElementsByTagName('img')->item(0);
+            $imageElement = clone $this->domElement->getElementsByTagName('img')->item(0);
             if (empty($imageElement)) {
                 return null;
             }


### PR DESCRIPTION
This is a bit tricky to explain, but when using the getThumbnail() method on an image this affects all instances of that image since it updates attributes on the XML DOM Element.

This causes the following behavior:
1.) An article is displayed with one image in the "story" field.
2.) A list of articles is presented where the same article exists and this list calls getThumbnail() on the first image it finds in the assets->images list.
3.) The client updates src, height and width on the same instance causing the image in the "story" field to also be a thumbnail.
