### PR TITLE
Optional injection of configuration through the constructor for the client.

### DIFF
--- a/lib/core/DrPublishApiClient.php
+++ b/lib/core/DrPublishApiClient.php
@@ -39,11 +39,16 @@ class DrPublishApiClient
     protected static $configs = null;
     private $curlInfo;
 
-    public function __construct($url, $publicationName)
+    public function __construct($url, $publicationName, $config = null)
     {
         $this->url = $url;
         $this->publicationName = $publicationName;
-        $this->readConfigs();
+
+        if ($config !== null) {
+            self::$configs = $config;
+        } else {
+            $this->readConfigs();
+        }
     }
 
     protected function readConfigs()

--- a/lib/web/DrPublishApiWebClient.php
+++ b/lib/web/DrPublishApiWebClient.php
@@ -10,9 +10,9 @@ unset($dpwebdn);
 class DrPublishApiWebClient extends DrPublishApiClient
 {
 
-    public function __construct($url, $publicationName)
+    public function __construct($url, $publicationName, $config = null)
     {
-        parent::__construct($url, $publicationName);
+        parent::__construct($url, $publicationName, $config);
         $this->setMedium('web');
     }
 


### PR DESCRIPTION
Add the possibility to inject configuration through the ctor instead of reading file with a predefined location.

We make a clean checkout of the client on every deployment and maintaining a configuration file inside will be cumbersome.

This allows us to handle the configuration as we wish and inject it upon creation of the client instance.
