### PR TITLE
Attempt to create the base cache dir before checking if it's writeable

### DIFF
--- a/lib/core/DrPublishApiClient.php
+++ b/lib/core/DrPublishApiClient.php
@@ -481,6 +481,11 @@ class DrPublishApiClient
         $dirString = $id[0] . $id[1] . '/' . $id[2] . $id[3] . '/' . $id[4] . $id[5];
         $cacheDir = $baseDir . '/' . $dirString;
         if ($write === true) {
+            if (!is_dir($baseDir)) {
+                umask(0000);
+                mkdir($baseDir, 0777, true);
+            }
+            
             if (!is_writable($baseDir)) {
                 trigger_error("Data cache directory '{$baseDir}' is not writable. DrPublishApiClient can't cache your data!", E_USER_WARNING);
                 return false;


### PR DESCRIPTION
We configure our application to have a data/ folder which is writable by Apache, if the client can attempt to create it's own base folder (data/drpublish/) we avoid handling this on deployment :)
