### PR TITLE
Make sure the data contains a service entry

### DIFF
--- a/lib/core/entities/DrPublishApiClientArticle.php
+++ b/lib/core/entities/DrPublishApiClientArticle.php
@@ -15,9 +15,11 @@ class DrPublishApiClientArticle
         $this->dpClient = $dpClient;
         $this->setMedium($dpClient->getMedium());
         $this->buildArticleXmlContentElements();
-        self::$imagePublishUrl =  $this->data->service->imagePublishUrl;
-        self::$imageServiceUrl =  $this->data->service->imageServiceUrl;
-
+        
+        if (!empty($this->data->service)) {
+            self::$imagePublishUrl = $this->data->service->imagePublishUrl;
+            self::$imageServiceUrl = $this->data->service->imageServiceUrl;
+        }
     }
 
     public function __set($name, $value)


### PR DESCRIPTION
If one searches articles via the client's searchArticles method, and specifies array('fields' => 'id') as an option, the service entry in the data object does not exist, causing notices.
