### PR TITLE
fixing missing 'position' property notice while iterating over article tags

### DIFF
--- a/lib/core/entities/DrPublishApiClientArticle.php
+++ b/lib/core/entities/DrPublishApiClientArticle.php
@@ -15,7 +15,7 @@ class DrPublishApiClientArticle
         $this->dpClient = $dpClient;
         $this->setMedium($dpClient->getMedium());
         $this->buildArticleXmlContentElements();
-        
+
         if (!empty($this->data->service)) {
             self::$imagePublishUrl = $this->data->service->imagePublishUrl;
             self::$imageServiceUrl = $this->data->service->imageServiceUrl;
@@ -235,12 +235,9 @@ class DrPublishApiClientArticle
 
     public function getMainDPTag()
     {
-
         if (!empty($this->data->meta->tags)) {
             foreach ($this->data->meta->tags as $tag) {
-                if ($tag->position === 1) {
-                    return $this->createDrPublishApiClientTag($tag);
-                }
+                return $this->createDrPublishApiClientTag($tag);
             }
         }
         return null;


### PR DESCRIPTION
At godt.no we're getting a lot of notices "Undefined property: stdClass::$position in ­vendor/­aptoma/­drpublish-api-client/­lib/­core/­entities/­DrPublishApiClientArticle.php:241". After investigating DrPublish API response, e.g. http://dp-api.vg.no/articles/20355197.json, you can see that there is no such attribute 'position'.

I prepared a PR which returns first tag as the MainDPTag.
