### PR TITLE
Returning property and not null every time

### DIFF
--- a/lib/core/helpers/DrPublishApiClientSearchList.php
+++ b/lib/core/helpers/DrPublishApiClientSearchList.php
@@ -73,7 +73,7 @@ class DrPublishApiClientSearch
     public function getProperty($name)
     {
         if (isset($this->data->{$name})) {
-            $this->data->{$name};
+            return $this->data->{$name};
         }
         return null;
     }


### PR DESCRIPTION
Useless method when the return method is not there.
