### PR TITLE
Added better error handling when resizing image

### DIFF
--- a/lib/core/DrPublishApiClient.php
+++ b/lib/core/DrPublishApiClient.php
@@ -676,7 +676,7 @@ class DrPublishApiClient
         $info = curl_getinfo($ch);
         $body = substr($res, $info['header_size']);
         $props = json_decode($body, true);
-        if (isset($props['error'])) {
+        if (is_null($props) || isset($props['error'])) {
             throw new DrPublishApiClientException('Error generating Image: ' . $props['error'], DrPublishApiClientException::IMAGE_CONVERTING_ERROR);
         }
         $props['src'] = str_replace($imageServiceUrl, $imagePublishUrl, $newSrc);


### PR DESCRIPTION
If not getting JSON back from the image service we end up without an exception. So I added a introspection to the `$props` that throws the exception if is `NULL`
